### PR TITLE
DRT-383-specific enum validation.

### DIFF
--- a/enum_test.go
+++ b/enum_test.go
@@ -15,9 +15,26 @@ func (self *enumResolver) Greet(args struct { Mood string }) string {
 	return fmt.Sprintf("Hi, %s!", args.Mood)
 }
 
+func (self *enumResolver) Leave(args struct { Moods *[]*string }) string {
+	retVal := "Bye";
+	for _, s := range *args.Moods {
+		retVal += ", " + *s
+	}
+	return retVal + "!"
+}
+
 func TestInvalidEnum(t *testing.T) {
+	varScalar := `
+	query($wrong: Mood!) {
+		greet(mood: $wrong)
+	}`
+	varList := `
+	query($wrong: [Mood]) {
+		leave(moods: $wrong)
+	}`
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
+			// misspelled scalar enum literal
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
 			query {
@@ -30,6 +47,7 @@ func TestInvalidEnum(t *testing.T) {
 			}},
 		},
 		{
+			// correct scalar enum literal
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
 			query {
@@ -38,26 +56,62 @@ func TestInvalidEnum(t *testing.T) {
 			ExpectedResult: `{ "greet": "Hi, WRUNG!" }`,
 		},
 		{
+			// misspelled list-of-enum literal
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
-			query($wrong: Mood!) {
-				greet(mood: $wrong)
+			query {
+				leave(moods: [WRONG])
 			}`,
-			Variables: map[string]interface{}{ "wrong": "WRONG" },
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Argument \"mood\" has invalid value $wrong.\nExpected type \"Mood\", found WRONG.",
-				Locations: []qerrors.Location{{Line: 3, Column: 17}},
+				Message: "Argument \"moods\" has invalid value [WRONG].\nIn element #0: Expected type \"Mood\", found WRONG.",
+				Locations: []qerrors.Location{{Line: 3, Column: 18}},
 				Rule: "ArgumentsOfCorrectType",
 			}},
 		},
 		{
+			// correct list-of-enum literal
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
-			query($wrong: Mood!) {
-				greet(mood: $wrong)
+			query {
+				leave(moods: [WRUNG])
 			}`,
+			ExpectedResult: `{ "leave": "Bye, WRUNG!" }`,
+		},
+		{
+			// misspelled scalar enum variable
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: varScalar,
+			Variables: map[string]interface{}{ "wrong": "WRONG" },
+			ExpectedErrors: []*qerrors.QueryError{{
+				Message: "Argument \"mood\" has invalid value $wrong.\nExpected type \"Mood\", found WRONG.",
+				Locations: []qerrors.Location{{Line: 3, Column: 15}},
+				Rule: "ArgumentsOfCorrectType",
+			}},
+		},
+		{
+			// correct scalar enum variable
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: varScalar,
 			Variables: map[string]interface{}{ "wrong": "WRUNG" },
 			ExpectedResult: `{ "greet": "Hi, WRUNG!" }`,
+		},
+		{
+			// misspelled list-of-enum variable
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: varList,
+			Variables: map[string]interface{}{ "wrong": `[WRONG]` },
+			ExpectedErrors: []*qerrors.QueryError{{
+				Message: "Argument \"moods\" has invalid value $wrong.\nIn element #0: Expected type \"Mood\", found WRONG.",
+				Locations: []qerrors.Location{{Line: 3, Column: 16}},
+				Rule: "ArgumentsOfCorrectType",
+			}},
+		},
+		{
+			// correct list-of-enum variable
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: varList,
+			Variables: map[string]interface{}{ "wrong": `[WRUNG]` },
+			ExpectedResult: `{ "leave": "Bye, [WRUNG]!" }`,
 		},
 	})
 }
@@ -74,5 +128,6 @@ const rightSchema = `
 
 	type Query {
 		greet(mood: Mood!): String!
+		leave(moods: [Mood]): String!
 	}
 `

--- a/enum_test.go
+++ b/enum_test.go
@@ -1,0 +1,63 @@
+package graphql_test
+
+import (
+	//"context"
+	//"errors"
+	"fmt"
+	"testing"
+
+	graphql "github.com/nauto/graphql-go"
+	qerrors "github.com/nauto/graphql-go/errors"
+	"github.com/nauto/graphql-go/gqltesting"
+)
+
+type enumResolver struct {}
+
+func (self *enumResolver) Greet(args struct { Mood string }) string {
+	return fmt.Sprintf("Hi, %s!", args.Mood)
+}
+
+func TestInvalidEnum(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
+			{
+				greet(mood: WRONG)
+			}`,
+			ExpectedErrors: []*qerrors.QueryError{{
+				Message: "Argument \"mood\" has invalid value WRONG.\nExpected type \"Mood\", found WRONG.",
+				Locations: []qerrors.Location{{Line: 3, Column: 17}},
+				Rule: "ArgumentsOfCorrectType",
+			}},
+		},
+		{
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
+			query($wrong: Mood!) {
+				greet(mood: $wrong)
+			}`,
+			Variables: map[string]interface{}{ "wrong": "WRONG" },
+			ExpectedErrors: []*qerrors.QueryError{{
+				Message: "Argument \"mood\" has invalid value WRONG.\nExpected type \"Mood\", found WRONG.",
+				Locations: []qerrors.Location{{Line: 3, Column: 17}},
+				Rule: "ArgumentsOfCorrectType",
+			}},
+		},
+	})
+}
+
+const rightSchema = `
+	schema {
+		query: Query
+	}
+
+	enum Mood {
+		RIGHT
+		WRUNG
+	}
+
+	type Query {
+		greet(mood: Mood!): String!
+	}
+`

--- a/enum_test.go
+++ b/enum_test.go
@@ -34,7 +34,7 @@ func TestInvalidEnum(t *testing.T) {
 	}`
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			// misspelled scalar enum literal
+			// 1. misspelled scalar enum literal
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
 			query {
@@ -47,7 +47,7 @@ func TestInvalidEnum(t *testing.T) {
 			}},
 		},
 		{
-			// correct scalar enum literal
+			// 2. correct scalar enum literal
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
 			query {
@@ -56,7 +56,7 @@ func TestInvalidEnum(t *testing.T) {
 			ExpectedResult: `{ "greet": "Hi, WRUNG!" }`,
 		},
 		{
-			// misspelled list-of-enum literal
+			// 3. misspelled list-of-enum literal
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
 			query {
@@ -69,7 +69,7 @@ func TestInvalidEnum(t *testing.T) {
 			}},
 		},
 		{
-			// correct list-of-enum literal
+			// 4. correct list-of-enum literal
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
 			query {
@@ -78,36 +78,36 @@ func TestInvalidEnum(t *testing.T) {
 			ExpectedResult: `{ "leave": "Bye, WRUNG!" }`,
 		},
 		{
-			// misspelled scalar enum variable
+			// 5. misspelled scalar enum variable
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: varScalar,
 			Variables: map[string]interface{}{ "wrong": "WRONG" },
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Argument \"mood\" has invalid value $wrong.\nExpected type \"Mood\", found WRONG.",
-				Locations: []qerrors.Location{{Line: 3, Column: 15}},
+				Message: "Expected type \"Mood\", found WRONG.",
+				Locations: []qerrors.Location{{Line: 2, Column: 8}, {Line: 3, Column: 15}},
 				Rule: "ArgumentsOfCorrectType",
 			}},
 		},
 		{
-			// correct scalar enum variable
+			// 6. correct scalar enum variable
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: varScalar,
 			Variables: map[string]interface{}{ "wrong": "WRUNG" },
 			ExpectedResult: `{ "greet": "Hi, WRUNG!" }`,
 		},
 		{
-			// misspelled list-of-enum variable
+			// 7. misspelled list-of-enum variable
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: varList,
 			Variables: map[string]interface{}{ "wrong": `[WRONG]` },
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Argument \"moods\" has invalid value $wrong.\nIn element #0: Expected type \"Mood\", found WRONG.",
-				Locations: []qerrors.Location{{Line: 3, Column: 16}},
+				Message: "In element #0: Expected type \"Mood\", found WRONG.",
+				Locations: []qerrors.Location{{Line: 2, Column: 8}, {Line: 3, Column: 16}},
 				Rule: "ArgumentsOfCorrectType",
 			}},
 		},
 		{
-			// correct list-of-enum variable
+			// 8. correct list-of-enum variable
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: varList,
 			Variables: map[string]interface{}{ "wrong": `[WRUNG]` },

--- a/enum_test.go
+++ b/enum_test.go
@@ -1,8 +1,6 @@
 package graphql_test
 
 import (
-	//"context"
-	//"errors"
 	"fmt"
 	"testing"
 
@@ -22,7 +20,7 @@ func TestInvalidEnum(t *testing.T) {
 		{
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
-			{
+			query {
 				greet(mood: WRONG)
 			}`,
 			ExpectedErrors: []*qerrors.QueryError{{
@@ -34,15 +32,32 @@ func TestInvalidEnum(t *testing.T) {
 		{
 			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
 			Query: `
+			query {
+				greet(mood: WRUNG)
+			}`,
+			ExpectedResult: `{ "greet": "Hi, WRUNG!" }`,
+		},
+		{
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
 			query($wrong: Mood!) {
 				greet(mood: $wrong)
 			}`,
 			Variables: map[string]interface{}{ "wrong": "WRONG" },
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Argument \"mood\" has invalid value WRONG.\nExpected type \"Mood\", found WRONG.",
+				Message: "Argument \"mood\" has invalid value $wrong.\nExpected type \"Mood\", found WRONG.",
 				Locations: []qerrors.Location{{Line: 3, Column: 17}},
 				Rule: "ArgumentsOfCorrectType",
 			}},
+		},
+		{
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
+			query($wrong: Mood!) {
+				greet(mood: $wrong)
+			}`,
+			Variables: map[string]interface{}{ "wrong": "WRUNG" },
+			ExpectedResult: `{ "greet": "Hi, WRUNG!" }`,
 		},
 	})
 }

--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -49,19 +49,21 @@ func RunTest(t *testing.T, test *Test) {
 	checkErrors(t, test.ExpectedErrors, result.Errors)
 
 	// Verify JSON to avoid red herring errors.
-	got, err := formatJSON(result.Data)
-	if err != nil {
-		t.Fatalf("got: invalid JSON: %s", err)
-	}
-	want, err := formatJSON([]byte(test.ExpectedResult))
-	if err != nil {
-		t.Fatalf("want: invalid JSON: %s", err)
-	}
+	if len(result.Data) != 0 || len(test.ExpectedResult) != 0 {
+		got, err := formatJSON(result.Data)
+		if err != nil {
+			t.Fatalf("got: invalid JSON: %s", err)
+		}
+		want, err := formatJSON([]byte(test.ExpectedResult))
+		if err != nil {
+			t.Fatalf("want: invalid JSON: %s", err)
+		}
 
-	if !bytes.Equal(got, want) {
-		t.Logf("got:  %s", got)
-		t.Logf("want: %s", want)
-		t.Fail()
+		if !bytes.Equal(got, want) {
+			t.Logf("got:  %s", got)
+			t.Logf("want: %s", want)
+			t.Fail()
+		}
 	}
 }
 

--- a/graphql.go
+++ b/graphql.go
@@ -161,7 +161,7 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 	}
 
 	validationFinish := s.validationTracer.TraceValidation()
-	errs := validation.Validate(s.schema, doc, s.maxDepth)
+	errs := validation.Validate(s.schema, doc, s.maxDepth, variables)
 	validationFinish(errs)
 	if len(errs) != 0 {
 		return &Response{Errors: errs}

--- a/graphql.go
+++ b/graphql.go
@@ -161,7 +161,7 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 	}
 
 	validationFinish := s.validationTracer.TraceValidation()
-	errs := validation.Validate(s.schema, doc, s.maxDepth, variables)
+	errs := validation.ValidateWithVariables(s.schema, doc, s.maxDepth, variables)
 	validationFinish(errs)
 	if len(errs) != 0 {
 		return &Response{Errors: errs}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -731,12 +731,13 @@ func validateValueType(c *opContext, v common.Literal, t common.Type) (bool, str
 				if _, ok := t2.(*common.NonNull); !ok && v2.Default != nil {
 					t2 = &common.NonNull{OfType: t2}
 				}
-				if err == nil {
-					if binding, ok := varBinding(c, v2.Name.Name); ok {
-						return validateValueType(c, binding, t2)
-					}
+				if err != nil {
+					continue
 				}
-				if err == nil && !typeCanBeUsedAs(t2, t) {
+				if binding, ok := varBinding(c, v2.Name.Name); ok {
+					return validateValueType(c, binding, t2)
+				}
+				if !typeCanBeUsedAs(t2, t) {
 					c.addErrMultiLoc([]errors.Location{v2.Loc, v.Loc}, "VariablesInAllowedPosition", "Variable %q of type %q used in position expecting type %q.", "$"+v.Name, t2, t)
 				}
 			}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -54,14 +54,7 @@ type opContext struct {
 	ops []*query.Operation
 }
 
-func newContext(s *schema.Schema, doc *query.Document, maxDepth int, varBindings ...bindings) *context {
-	var variables bindings
-	if len(varBindings) == 0 {
-		variables = bindings{}
-	} else {
-		variables = varBindings[0]
-	}
-
+func newContext(s *schema.Schema, doc *query.Document, maxDepth int, variables bindings) *context {
 	return &context{
 		schema:           s,
 		doc:              doc,
@@ -74,8 +67,16 @@ func newContext(s *schema.Schema, doc *query.Document, maxDepth int, varBindings
 	}
 }
 
-func Validate(s *schema.Schema, doc *query.Document, maxDepth int, variables ...map[string]interface{}) []*errors.QueryError {
-	c := newContext(s, doc, maxDepth, variables...)
+func Validate(s *schema.Schema, doc *query.Document, maxDepth int) []*errors.QueryError {
+	return validate(s, doc, maxDepth, bindings{})
+}
+
+func ValidateWithVariables(s *schema.Schema, doc *query.Document, maxDepth int, variables bindings) []*errors.QueryError {
+	return validate(s, doc, maxDepth, variables)
+}
+
+func validate(s *schema.Schema, doc *query.Document, maxDepth int, variables bindings) []*errors.QueryError {
+	c := newContext(s, doc, maxDepth, variables)
 
 	opNames := make(nameSet)
 	fragUsedBy := make(map[*query.FragmentDecl][]*query.Operation)

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -735,7 +735,9 @@ func validateValueType(c *opContext, v common.Literal, t common.Type) (bool, str
 					continue
 				}
 				if binding, ok := varBinding(c, v2.Name.Name); ok {
-					return validateValueType(c, binding, t2)
+					if ok, errstr := validateValueType(c, binding, t2); !ok {
+						c.addErrMultiLoc([]errors.Location{v2.Loc, v.Loc}, "ArgumentsOfCorrectType", errstr)
+					}
 				}
 				if !typeCanBeUsedAs(t2, t) {
 					c.addErrMultiLoc([]errors.Location{v2.Loc, v.Loc}, "VariablesInAllowedPosition", "Variable %q of type %q used in position expecting type %q.", "$"+v.Name, t2, t)

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -23,8 +23,6 @@ type fieldInfo struct {
 	parent schema.NamedType
 }
 
-type bindings = map[string]interface{}
-
 type context struct {
 	schema           *schema.Schema
 	doc              *query.Document
@@ -34,7 +32,7 @@ type context struct {
 	fieldMap         map[*query.Field]fieldInfo
 	overlapValidated map[selectionPair]struct{}
 	maxDepth         int
-	variables        bindings
+	variables        map[string]interface{}
 }
 
 func (c *context) addErr(loc errors.Location, rule string, format string, a ...interface{}) {
@@ -54,7 +52,7 @@ type opContext struct {
 	ops []*query.Operation
 }
 
-func newContext(s *schema.Schema, doc *query.Document, maxDepth int, variables bindings) *context {
+func newContext(s *schema.Schema, doc *query.Document, maxDepth int, variables map[string]interface{}) *context {
 	return &context{
 		schema:           s,
 		doc:              doc,
@@ -68,14 +66,14 @@ func newContext(s *schema.Schema, doc *query.Document, maxDepth int, variables b
 }
 
 func Validate(s *schema.Schema, doc *query.Document, maxDepth int) []*errors.QueryError {
-	return validate(s, doc, maxDepth, bindings{})
+	return validate(s, doc, maxDepth, nil)
 }
 
-func ValidateWithVariables(s *schema.Schema, doc *query.Document, maxDepth int, variables bindings) []*errors.QueryError {
+func ValidateWithVariables(s *schema.Schema, doc *query.Document, maxDepth int, variables map[string]interface{}) []*errors.QueryError {
 	return validate(s, doc, maxDepth, variables)
 }
 
-func validate(s *schema.Schema, doc *query.Document, maxDepth int, variables bindings) []*errors.QueryError {
+func validate(s *schema.Schema, doc *query.Document, maxDepth int, variables map[string]interface{}) []*errors.QueryError {
 	c := newContext(s, doc, maxDepth, variables)
 
 	opNames := make(nameSet)


### PR DESCRIPTION
This PR amends the way arguments are validated in Operations. Now, if an argument holds a reference to a variable as its value, the variable's value itself is considered for type compatibility.
As a consequence, incorrect enum values stored in variables are now caught at validation stage and not passed further to the resolver, as was the case before.
Relevant test cases were added, contained in the file enum_test.go under project's top-level directory.