### PR TITLE
Drt 743 graphql panic

### DIFF
--- a/enum_test.go
+++ b/enum_test.go
@@ -174,7 +174,7 @@ func TestInvalidEnum(t *testing.T) {
 			query($justso: String!) {
 				crash(why: $justso)
 			}`,
-			Variables: map[string]interface{}{"justso": ""},
+			Variables:      map[string]interface{}{"justso": ""},
 			ExpectedResult: `{ "crash": "When, !" }`,
 		},
 	})

--- a/enum_test.go
+++ b/enum_test.go
@@ -23,6 +23,10 @@ func (self *enumResolver) Leave(args struct{ Moods *[]*string }) string {
 	return retVal + "!"
 }
 
+func (self *enumResolver) Grasp(args struct{ None *string }) string {
+	return fmt.Sprintf("None, %s.", *args.None)
+}
+
 func TestInvalidEnum(t *testing.T) {
 	varScalar := `
 	query($wrong: Mood!) {
@@ -137,6 +141,19 @@ func TestInvalidEnum(t *testing.T) {
 				Rule:      "ArgumentsOfCorrectType",
 			}},
 		},
+		{
+			// 11. spelled empty enum literal
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
+			query {
+				grasp(none: NOTHING)
+			}`,
+			ExpectedErrors: []*qerrors.QueryError{{
+				Message:   "Argument \"none\" has invalid value NOTHING.\nExpected type \"Nothing\", found NOTHING.",
+				Locations: []qerrors.Location{{Line: 3, Column: 17}},
+				Rule:      "ArgumentsOfCorrectType",
+			}},
+		},
 	})
 }
 
@@ -150,8 +167,12 @@ const rightSchema = `
 		WRUNG
 	}
 
+	enum Nothing {
+	}
+
 	type Query {
 		greet(mood: Mood!): String!
 		leave(moods: [Mood]): String!
+		grasp(none: Nothing): String!
 	}
 `

--- a/enum_test.go
+++ b/enum_test.go
@@ -113,6 +113,30 @@ func TestInvalidEnum(t *testing.T) {
 			Variables: map[string]interface{}{ "wrong": `[WRUNG]` },
 			ExpectedResult: `{ "leave": "Bye, [WRUNG]!" }`,
 		},
+		{
+			// 9. misspelled again scalar enum literal
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
+			query {
+				greet(mood: WRU)
+			}`,
+			ExpectedErrors: []*qerrors.QueryError{{
+				Message: "Argument \"mood\" has invalid value WRU.\nExpected type \"Mood\", found WRU.",
+				Locations: []qerrors.Location{{Line: 3, Column: 17}},
+				Rule: "ArgumentsOfCorrectType",
+			}},
+		},
+		{
+			// 10. misspelled again scalar enum variable
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: varScalar,
+			Variables: map[string]interface{}{ "wrong": "WRU" },
+			ExpectedErrors: []*qerrors.QueryError{{
+				Message: "Expected type \"Mood\", found WRU.",
+				Locations: []qerrors.Location{{Line: 2, Column: 8}, {Line: 3, Column: 15}},
+				Rule: "ArgumentsOfCorrectType",
+			}},
+		},
 	})
 }
 

--- a/enum_test.go
+++ b/enum_test.go
@@ -175,7 +175,7 @@ func TestInvalidEnum(t *testing.T) {
 				crash(why: $justso)
 			}`,
 			Variables:      map[string]interface{}{"justso": ""},
-			ExpectedResult: `{ "crash": "When, !" }`,
+			ExpectedResult: `{ "crash": "Why, !" }`,
 		},
 	})
 }

--- a/enum_test.go
+++ b/enum_test.go
@@ -177,6 +177,16 @@ func TestInvalidEnum(t *testing.T) {
 			Variables:      map[string]interface{}{"justso": ""},
 			ExpectedResult: `{ "crash": "Why, !" }`,
 		},
+		{
+			// 14. an arbitrary string
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
+			query($justso: String!) {
+				crash(why: $justso)
+			}`,
+			Variables:      map[string]interface{}{"justso": "!hola"},
+			ExpectedResult: `{ "crash": "Why, !hola!" }`,
+		},
 	})
 }
 

--- a/enum_test.go
+++ b/enum_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/nauto/graphql-go/gqltesting"
 )
 
-type enumResolver struct {}
+type enumResolver struct{}
 
-func (self *enumResolver) Greet(args struct { Mood string }) string {
+func (self *enumResolver) Greet(args struct{ Mood string }) string {
 	return fmt.Sprintf("Hi, %s!", args.Mood)
 }
 
-func (self *enumResolver) Leave(args struct { Moods *[]*string }) string {
-	retVal := "Bye";
+func (self *enumResolver) Leave(args struct{ Moods *[]*string }) string {
+	retVal := "Bye"
 	for _, s := range *args.Moods {
 		retVal += ", " + *s
 	}
@@ -41,9 +41,9 @@ func TestInvalidEnum(t *testing.T) {
 				greet(mood: WRONG)
 			}`,
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Argument \"mood\" has invalid value WRONG.\nExpected type \"Mood\", found WRONG.",
+				Message:   "Argument \"mood\" has invalid value WRONG.\nExpected type \"Mood\", found WRONG.",
 				Locations: []qerrors.Location{{Line: 3, Column: 17}},
-				Rule: "ArgumentsOfCorrectType",
+				Rule:      "ArgumentsOfCorrectType",
 			}},
 		},
 		{
@@ -63,9 +63,9 @@ func TestInvalidEnum(t *testing.T) {
 				leave(moods: [WRONG])
 			}`,
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Argument \"moods\" has invalid value [WRONG].\nIn element #0: Expected type \"Mood\", found WRONG.",
+				Message:   "Argument \"moods\" has invalid value [WRONG].\nIn element #0: Expected type \"Mood\", found WRONG.",
 				Locations: []qerrors.Location{{Line: 3, Column: 18}},
-				Rule: "ArgumentsOfCorrectType",
+				Rule:      "ArgumentsOfCorrectType",
 			}},
 		},
 		{
@@ -79,38 +79,38 @@ func TestInvalidEnum(t *testing.T) {
 		},
 		{
 			// 5. misspelled scalar enum variable
-			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
-			Query: varScalar,
-			Variables: map[string]interface{}{ "wrong": "WRONG" },
+			Schema:    graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query:     varScalar,
+			Variables: map[string]interface{}{"wrong": "WRONG"},
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Expected type \"Mood\", found WRONG.",
+				Message:   "Expected type \"Mood\", found WRONG.",
 				Locations: []qerrors.Location{{Line: 2, Column: 8}, {Line: 3, Column: 15}},
-				Rule: "ArgumentsOfCorrectType",
+				Rule:      "ArgumentsOfCorrectType",
 			}},
 		},
 		{
 			// 6. correct scalar enum variable
-			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
-			Query: varScalar,
-			Variables: map[string]interface{}{ "wrong": "WRUNG" },
+			Schema:         graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query:          varScalar,
+			Variables:      map[string]interface{}{"wrong": "WRUNG"},
 			ExpectedResult: `{ "greet": "Hi, WRUNG!" }`,
 		},
 		{
 			// 7. misspelled list-of-enum variable
-			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
-			Query: varList,
-			Variables: map[string]interface{}{ "wrong": `[WRONG]` },
+			Schema:    graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query:     varList,
+			Variables: map[string]interface{}{"wrong": `[WRONG]`},
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "In element #0: Expected type \"Mood\", found WRONG.",
+				Message:   "In element #0: Expected type \"Mood\", found WRONG.",
 				Locations: []qerrors.Location{{Line: 2, Column: 8}, {Line: 3, Column: 16}},
-				Rule: "ArgumentsOfCorrectType",
+				Rule:      "ArgumentsOfCorrectType",
 			}},
 		},
 		{
 			// 8. correct list-of-enum variable
-			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
-			Query: varList,
-			Variables: map[string]interface{}{ "wrong": `[WRUNG]` },
+			Schema:         graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query:          varList,
+			Variables:      map[string]interface{}{"wrong": `[WRUNG]`},
 			ExpectedResult: `{ "leave": "Bye, [WRUNG]!" }`,
 		},
 		{
@@ -121,20 +121,20 @@ func TestInvalidEnum(t *testing.T) {
 				greet(mood: WRU)
 			}`,
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Argument \"mood\" has invalid value WRU.\nExpected type \"Mood\", found WRU.",
+				Message:   "Argument \"mood\" has invalid value WRU.\nExpected type \"Mood\", found WRU.",
 				Locations: []qerrors.Location{{Line: 3, Column: 17}},
-				Rule: "ArgumentsOfCorrectType",
+				Rule:      "ArgumentsOfCorrectType",
 			}},
 		},
 		{
 			// 10. misspelled again scalar enum variable
-			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
-			Query: varScalar,
-			Variables: map[string]interface{}{ "wrong": "WRU" },
+			Schema:    graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query:     varScalar,
+			Variables: map[string]interface{}{"wrong": "WRU"},
 			ExpectedErrors: []*qerrors.QueryError{{
-				Message: "Expected type \"Mood\", found WRU.",
+				Message:   "Expected type \"Mood\", found WRU.",
 				Locations: []qerrors.Location{{Line: 2, Column: 8}, {Line: 3, Column: 15}},
-				Rule: "ArgumentsOfCorrectType",
+				Rule:      "ArgumentsOfCorrectType",
 			}},
 		},
 	})

--- a/enum_test.go
+++ b/enum_test.go
@@ -27,6 +27,10 @@ func (self *enumResolver) Grasp(args struct{ None *string }) string {
 	return fmt.Sprintf("None, %s.", *args.None)
 }
 
+func (self *enumResolver) Crash(args struct{ Why string }) string {
+	return fmt.Sprintf("Why, %s!", args.Why)
+}
+
 func TestInvalidEnum(t *testing.T) {
 	varScalar := `
 	query($wrong: Mood!) {
@@ -154,6 +158,25 @@ func TestInvalidEnum(t *testing.T) {
 				Rule:      "ArgumentsOfCorrectType",
 			}},
 		},
+		{
+			// 12. empty string literal
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
+			query {
+				crash(why: "")
+			}`,
+			ExpectedResult: `{ "crash": "Why, !" }`,
+		},
+		{
+			// 13. empty string variable
+			Schema: graphql.MustParseSchema(rightSchema, &enumResolver{}),
+			Query: `
+			query($justso: String!) {
+				crash(why: $justso)
+			}`,
+			Variables: map[string]interface{}{"justso": ""},
+			ExpectedResult: `{ "crash": "When, !" }`,
+		},
 	})
 }
 
@@ -174,5 +197,6 @@ const rightSchema = `
 		greet(mood: Mood!): String!
 		leave(moods: [Mood]): String!
 		grasp(none: Nothing): String!
+		crash(why: String!): String!
 	}
 `

--- a/internal/common/lexer.go
+++ b/internal/common/lexer.go
@@ -52,6 +52,17 @@ func (l *Lexer) Peek() rune {
 	return l.next
 }
 
+// Advance reads, and returns, next character from the stream and makes it observable via Peek() no matter what that character is.
+//
+// Consequently, any leading whitespace is not skipped.
+func (l *Lexer) Advance() rune {
+	if !l.useStringDescriptions {
+		l.descComment = ""
+	}
+	l.next = l.sc.Scan()
+	return l.next
+}
+
 // ConsumeWhitespace consumes whitespace and tokens equivalent to whitespace (e.g. commas and comments).
 //
 // Consumed comment characters will build the description for the next type or field encountered.

--- a/internal/validation/validate_max_depth_test.go
+++ b/internal/validation/validate_max_depth_test.go
@@ -435,7 +435,7 @@ func TestMaxDepthValidation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			context := newContext(s, doc, tc.maxDepth)
+			context := newContext(s, doc, tc.maxDepth, nil)
 			op := doc.Operations[0]
 
 			opc := &opContext{context: context, ops: doc.Operations}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -706,7 +706,7 @@ func stringLiteral(value string) common.Literal {
 	return &common.BasicLit{Type: scanner.String, Text: value}
 }
 
-func parseLiteral(value string) common.Literal {
+func parseWhole(value string) common.Literal {
 	if value == "" {
 		return stringLiteral("")
 	}
@@ -729,19 +729,11 @@ func varBinding(c *opContext, name string) (rv common.Literal, success bool) {
 			return literal, true
 		}
 
-		defer func() {
-			if ex := recover(); ex != nil {
-				// ParseLiteral panicked
-				rv = nil
-				success = false
-			}
-		}()
-
 		switch literal := binding.(type) {
 		case string:
-			return parseLiteral(literal), true
+			return parseWhole(literal), true
 		case []byte:
-			return parseLiteral(string(literal)), true
+			return parseWhole(string(literal)), true
 		case uint8, uint16, uint32, uint64, int8, int16, int32, int64:
 			return &common.BasicLit{Type: scanner.Int, Text: fmt.Sprintf("%v", literal)}, true
 		case float32, float64:

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -727,9 +727,9 @@ func varBinding(c *opContext, name string) (rv common.Literal, success bool) {
 		case []byte:
 			return parseLiteral(string(literal)), true
 		case uint8, uint16, uint32, uint64, int8, int16, int32, int64:
-			return &common.BasicLit{ Type: scanner.Int, Text: fmt.Sprintf("%v", literal) }, true
+			return &common.BasicLit{Type: scanner.Int, Text: fmt.Sprintf("%v", literal)}, true
 		case float32, float64:
-			return &common.BasicLit{ Type: scanner.Float, Text: fmt.Sprintf("%v", literal) }, true
+			return &common.BasicLit{Type: scanner.Float, Text: fmt.Sprintf("%v", literal)}, true
 		}
 	}
 	return nil, false

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -722,7 +722,7 @@ func parseWhole(value string) (rv common.Literal) {
 	return stringLiteral(value)
 }
 
-func varBinding(c *opContext, name string) (rv common.Literal, success bool) {
+func varBinding(c *opContext, name string) (common.Literal, bool) {
 	if binding, ok := c.variables[name]; ok {
 		if literal, ok := binding.(common.Literal); ok {
 			return literal, true

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -706,7 +706,7 @@ func stringLiteral(value string) common.Literal {
 	return &common.BasicLit{Type: scanner.String, Text: value}
 }
 
-func parseWhole(value string) common.Literal {
+func parseWhole(value string) (rv common.Literal) {
 	if value == "" {
 		return stringLiteral("")
 	}
@@ -715,12 +715,19 @@ func parseWhole(value string) common.Literal {
 		// assuming values of other scalar types don't start with spaces
 		return stringLiteral(value)
 	}
-	rv := common.ParseLiteral(lexer, true)
+
+	defer func() {
+		if ex := recover(); rv == nil || ex != nil {
+			rv = stringLiteral(value)
+		}
+	}()
+
+	rv = common.ParseLiteral(lexer, true)
 	if lexer.Peek() != scanner.EOF {
 		// if it can be parsed as several simple values it is assumed to be a string
-		return stringLiteral(value)
+		rv = nil
 	}
-	return rv
+	return
 }
 
 func varBinding(c *opContext, name string) (rv common.Literal, success bool) {


### PR DESCRIPTION
`varBinding()` now `recover`s from `panic`s; additionally, few numeric literal types were added to `varBinding()` just in case variables are defined as such in the dictionary.